### PR TITLE
Update issue templates epic<>milestone rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Handled by insight team
 
 **Weekly**: Report progress on each **active** _Epic_ or _Task_ per subteam.
 
-Every Friday, all team members must add a comment to the GH issues they own and worked on the past week or planned to work on next week.
+Every Friday, all team members must add a comment to the GH **issues** (not pull request) they own and worked on the past week or planned to work on next week.
 
 If work is done on several _Tasks_ related to the same _Epic_, team member is free to do their weekly update in common parent issue.
 

--- a/README.md
+++ b/README.md
@@ -22,23 +22,17 @@ Weekly reporting by subteam of progress on milestones.
 
 #### 2. Monthly Reporting
 
-Monthly reporting is currently done in a private Google Sheet and has the following sections:
-- Progress on yearly milestones (10 milestones as defined in https://notes.status.im/Uz9HeCwZTDSYyOq36Q54cA#, now marked as _Epics_).
-- Key achievements/highlights of previous month
-- Planned achievement for next month
-- RAID: Risks, Assumptions, Issues and Dependencies
-- Identified Market Opportunities
-
-The Google Sheet will soon be replaced by a dashboard that extract data using GitHub with the ability to organise the data by epic using GitHub labels.
+Monthly reporting is now handled by the Logos insight team.
 
 ### Terminology
 
-| Name            | Number of                           | Timeframe                            | Team Scope                              | Owner       | Description                                                                 |
-|-----------------|-------------------------------------|--------------------------------------|-----------------------------------------|-------------|-----------------------------------------------------------------------------|
-| Priority Track  | 3-5                                 | Set yearly                           | Whole Team                              | Waku Lead   | Focus set for the year, must be aligned with Logos Collective's priorities. |
-| (Key) Milestone | 2-3 per _Priority Track_, total<=10 | Set yearly, delivered quarterly-ish  | Several subteams                        | Waku Lead   | Identified deliverables for each _Priority Track_.                          |
-| Epic            | Some per Milestone                  | Set quarterly-ish, delivered monthly | One subteam or external team (e.g. DST) | Team Member | Steps to deliver a _Milestone_.                                             |
-| Task            | Many per Epic                       | Set monthly-ish, delivered weekly    | One individual                          | Team Member | Smallest chunk of work to be delivered.                                     |  
+| Name         | Number of                                 | Timeframe                              | Team Scope                          | Owner                       | Description                                                                   |
+|--------------|-------------------------------------------|----------------------------------------|-------------------------------------|-----------------------------|-------------------------------------------------------------------------------|
+| Priority Track | 3-5                                       | Set yearly                             | Whole Team                          | Waku Lead                   | Focus set for the year, must be aligned with Logos Collective's priorities.   |
+| (Key) Milestone | 1-3 per year                              | Set yearlyish                          | Most subteams                       | Waku Lead                   | This are key achievements for the Waku projects, they are historic milestones. |
+| Epic of Epics | Several per milestone                     | Set for a milestone, delivered monthly | Several or external team (e.g. DST) | Team Member (likely a lead) | Chunk of a _Milestone.                                                        |
+| Epic   | One per subteam for a given epic of epics | Delivered monthly                      | One subteam                         | Team Member                 | Chunk of a _Milestone.                                                        |
+| Task         | Many per Epic                             | Set monthly-ish, delivered weekly      | One individual                      | Team Member                 | Smallest chunk of work to be delivered.                                       |  
 
 Owner = person responsible for the delivery of the milestone and related reporting.
 
@@ -46,28 +40,32 @@ Owner = person responsible for the delivery of the milestone and related reporti
 
 For each:
 
-- _Milestone_, there is a GH issue under the https://github.com/waku-org/pm repo with `milestone` label assigned
-- _Milestone_, there is a label with format `E:<year>-<milestone title>` created across all relevant https://github.com/waku-org/ repos (see [labels.yml](./.github/labels.yml)).
-- _Epic_, there is a GH issue under the relevant https://github.com/waku-org/ repo with related _Milestone_ label (`E:...`) and `epic` label assigned. The GH issue is assigned to the _owner_ of the epic.
-- _Task_, there is a GH issue and/or pull request under the relevant https://github.com/waku-org/ repo with related _Epic_ label.
+- _Milestone_, there is a GH issue in the https://github.com/waku-org/pm repo with `milestone` label assigned
+- _Milestone_, there is a GH Milestone in https://github.com/waku-org/pm repo, to which relevant _Epics of epics_ are added.
+- _Epic of epics_, there is a GH issue in the https://github.com/waku-org/pm with `epic` label assigned.
+- _Epic of epics_, there is the label with format `E:<epic name>` created across all relevant https://github.com/waku-org/ repos (see [labels.yml](./.github/labels.yml)).
+- _Epic_, there is a GH issue under the relevant https://github.com/waku-org/ repo with related _Epic of epics_ label (`E:...`) and `epic` label assigned. The GH issue is assigned to the _owner_ of the epic.
+- _Task_, there is a GH issue and/or pull request under the relevant https://github.com/waku-org/ repo with related _Epic of epics_ label (`E:...`).
 
-Hence, correct _Milestone_ label must be assigned to all GH issues/pull requests representing a _Milestone_ or _Task_.
+Hence, correct _Epic of epics_ (`E:...`) label must be assigned to all GH issues/pull requests representing a _Epic_ or _Task_.
 This will enable the usage of the new reporting dashboard and reduce manual maintenance.
 
-Ideally, every:
+Also note that GitHub milestones and GitHub issues for _Epic of epics_ are both limited to the https://github.com/waku-org/pm repo. We are not duplicate GitHub milestones across the repo..
 
-- _Milestone_ GH issue contains a list of planned _Epics_.
-- _Epic_ GH issue contains list of planned and completed _Tasks_.
+Which means, in terms of _navigation_:
 
-Note: GitHub `milestone` functionality is **not** used as part of this process.
+- Work for a Milestone is described in the related GitHub issue and tracked in the GitHub milestone.
+- In the GitHub milestone, we have a list of _Epics of epics_ to be achieved, the _epics of epics_ are being closed as the work is done across all clients.
+- To look at remaining work for an _epics of epics_, one need to look at all issues (_epics_ and _tasks_) with the corresponding _epic of epics_ label (`E:...`)
+
+Finally, ideally an _Epic of epics_ do list the _epics_ as a todo list in the GH issue description, but it's not mandatory for tracking.
+The same way, an _Epic_ should list the _tasks_ as a todo list in the GH issue description, but it's not mandatory as long as the _acceptance criteria_ is clearly defined.
 
 ### Reporting
 
 **Monthly**:
 
-- Report progress of each _Milestone_
-- Report _Epics_ that were closed last months and expected to be closed next month
-- Other relevant items (RISK, etc)
+Handled by insight team
 
 **Weekly**: Report progress on each **active** _Epic_ per subteam.
 
@@ -93,7 +91,7 @@ On Monday, project lead or responsible person for report can run the [milestone-
 
 **Priority Tracks**: https://notes.status.im/Uz9HeCwZTDSYyOq36Q54cA#a
 
-**Milestones** (WIP):
+**Milestones** (to be changed):
 
 - `E:2023-light-protocols` https://github.com/waku-org/pm/issues/25
 - `E:2023-10k-users` https://github.com/waku-org/pm/issues/12

--- a/README.md
+++ b/README.md
@@ -26,36 +26,48 @@ Monthly reporting is now handled by the Logos insight team.
 
 ### Terminology
 
-| Name         | Number of                                 | Timeframe                              | Team Scope                          | Owner                       | Description                                                                   |
-|--------------|-------------------------------------------|----------------------------------------|-------------------------------------|-----------------------------|-------------------------------------------------------------------------------|
-| Priority Track | 3-5                                       | Set yearly                             | Whole Team                          | Waku Lead                   | Focus set for the year, must be aligned with Logos Collective's priorities.   |
-| (Key) Milestone | 1-3 per year                              | Set yearlyish                          | Most subteams                       | Waku Lead                   | This are key achievements for the Waku projects, they are historic milestones. |
-| Epic of Epics | Several per milestone                     | Set for a milestone, delivered monthly | Several or external team (e.g. DST) | Team Member (likely a lead) | Chunk of a _Milestone.                                                        |
-| Epic   | One per subteam for a given epic of epics | Delivered monthly                      | One subteam                         | Team Member                 | Chunk of a _Milestone.                                                        |
-| Task         | Many per Epic                             | Set monthly-ish, delivered weekly      | One individual                      | Team Member                 | Smallest chunk of work to be delivered.                                       |  
+| Name            | Number of                                 | Timeframe                              | Team Scope                                   | Owner                       | Description                                                                 |
+|-----------------|-------------------------------------------|----------------------------------------|----------------------------------------------|-----------------------------|-----------------------------------------------------------------------------|
+| Priority Track  | 3-5                                       | Set yearly                             | Whole Team                                   | Waku Lead                   | Focus set for the year, must be aligned with Logos Collective's priorities. |
+| (Key) Milestone | 1-3 per year                              | Set yearlyish                          | Most subteams                                | Waku Lead                   | Key achievements for the Waku project, historical milestones.               |
+| Epic of Epics   | Several per milestone                     | Set for a milestone, delivered monthly | Several subteams or external team (e.g. DST) | Team Member (likely a lead) | Chunk of a _Milestone across all clients.                                   |
+| Epic            | One per subteam for a given epic of epics | Delivered monthly                      | One subteam                                  | Team Member                 | Chunk of a _Milestone for a given client.                                   |
+| Task            | Many per Epic                             | Set monthly-ish, delivered weekly      | One individual                               | Team Member                 | Smallest chunk of work to be delivered.                                     |  
 
 Owner = person responsible for the delivery of the milestone and related reporting.
 
 ### GitHub Usage
 
-For each:
+A _Milestone_:
+- MUST have a matching GH issue in the https://github.com/waku-org/pm repo with `milestone` label assigned.
+- MUST have a GH Milestone in https://github.com/waku-org/pm repo, to which relevant _Epics of epics_ are added.
+- SHOULD have a roadmap to delivery done at planning phase, the GH milestone is then used to track progress.
 
-- _Milestone_, there is a GH issue in the https://github.com/waku-org/pm repo with `milestone` label assigned
-- _Milestone_, there is a GH Milestone in https://github.com/waku-org/pm repo, to which relevant _Epics of epics_ are added.
-- _Epic of epics_, there is a GH issue in the https://github.com/waku-org/pm with `epic` label assigned.
-- _Epic of epics_, there is the label with format `E:<epic name>` created across all relevant https://github.com/waku-org/ repos (see [labels.yml](./.github/labels.yml)).
-- _Epic_, there is a GH issue under the relevant https://github.com/waku-org/ repo with related _Epic of epics_ label (`E:...`) and `epic` label assigned. The GH issue is assigned to the _owner_ of the epic.
-- _Task_, there is a GH issue and/or pull request under the relevant https://github.com/waku-org/ repo with related _Epic of epics_ label (`E:...`).
+An _Epic of epics_:
+- MUST have a matching GH issue in the https://github.com/waku-org/pm with `epic` label assigned.
+- MUST have a label with format `E:<epic name>` created across all relevant https://github.com/waku-org/ repos (see [labels.yml](./.github/labels.yml)).
+- SHOULD be added to a GH Milestone.
+- SHOULD list _Epics_ present in other repos.
 
-Hence, correct _Epic of epics_ (`E:...`) label must be assigned to all GH issues/pull requests representing a _Epic_ or _Task_.
-This will enable the usage of the new reporting dashboard and reduce manual maintenance.
+An _Epic_:
+- MUST have a matching GH issue under the relevant https://github.com/waku-org/ repo, that
+  - MUST BE labelled with related _Epic of epics_ label (`E:...`)
+  - MUST BE labelled `epic` label.
+  - MUST be assigned to the _owner_ of the _Epic_.
+  - SHOULD contain a list of _Tasks_ in its issue description.
 
-Also note that GitHub milestones and GitHub issues for _Epic of epics_ are both limited to the https://github.com/waku-org/pm repo. We are not duplicate GitHub milestones across the repo..
+A _Task_:
+- MAY be tracked as a todo item in an _Epic_ GH Issue,
+- OR MAY be tracked as GH issue
+  - that SHOULD be labelled with related _Epic of epics_ label (`E:...`),
+- OR MAY be tracked as a GH Pull Request
+  - that SHOULD be labelled with related _Epic of epics_ label (`E:...`).
+
 
 Which means, in terms of _navigation_:
 
 - Work for a Milestone is described in the related GitHub issue and tracked in the GitHub milestone.
-- In the GitHub milestone, we have a list of _Epics of epics_ to be achieved, the _epics of epics_ are being closed as the work is done across all clients.
+- In the GitHub milestone, we have a list of _Epics of epics_ to be achieved, the _Epics of epics_ are being closed as the work is done across all clients.
 - To look at remaining work for an _epics of epics_, one need to look at all issues (_epics_ and _tasks_) with the corresponding _epic of epics_ label (`E:...`)
 
 Finally, ideally an _Epic of epics_ do list the _epics_ as a todo list in the GH issue description, but it's not mandatory for tracking.

--- a/README.md
+++ b/README.md
@@ -26,52 +26,41 @@ Monthly reporting is now handled by the Logos insight team.
 
 ### Terminology
 
-| Name            | Number of                                 | Timeframe                              | Team Scope                                   | Owner                       | Description                                                                 |
-|-----------------|-------------------------------------------|----------------------------------------|----------------------------------------------|-----------------------------|-----------------------------------------------------------------------------|
-| Priority Track  | 3-5                                       | Set yearly                             | Whole Team                                   | Waku Lead                   | Focus set for the year, must be aligned with Logos Collective's priorities. |
-| (Key) Milestone | 1-3 per year                              | Set yearlyish                          | Most subteams                                | Waku Lead                   | Key achievements for the Waku project, historical milestones.               |
-| Epic of Epics   | Several per milestone                     | Set for a milestone, delivered monthly | Several subteams or external team (e.g. DST) | Team Member (likely a lead) | Chunk of a _Milestone across all clients.                                   |
-| Epic            | One per subteam for a given epic of epics | Delivered monthly                      | One subteam                                  | Team Member                 | Chunk of a _Milestone for a given client.                                   |
-| Task            | Many per Epic                             | Set monthly-ish, delivered weekly      | One individual                               | Team Member                 | Smallest chunk of work to be delivered.                                     |  
+| Name            | Number of                               | Timeframe                              | Team Scope                                   | Owner                       | Description                                                                 |
+|-----------------|-----------------------------------------|----------------------------------------|----------------------------------------------|-----------------------------|-----------------------------------------------------------------------------|
+| Priority Track  | 3-5                                     | Set yearly                             | Whole Team                                   | Waku Lead                   | Focus set for the year, must be aligned with Logos Collective's priorities. |
+| (Key) Milestone | 1-3 per year                            | Set yearly-ish                         | Most subteams                                | Waku Lead                   | Key achievements for the Waku project, historical milestones.               |
+| Epic            | Several per milestone                   | Set for a milestone, delivered monthly | Several subteams or external team (e.g. DST) | Team Member (likely a lead) | Chunk of a _Milestone_ across all clients.                                  |
+| Task            | Many per Epic                           | Set monthly-ish, delivered weekly      | One subteam or individual                    | Team Member                 | May be one or several piece of work, client specific.                       |  
 
-Owner = person responsible for the delivery of the milestone and related reporting.
+Owner = person responsible for the delivery and related reporting, may not be doing all the work.
 
 ### GitHub Usage
 
 A _Milestone_:
 - MUST have a matching GH issue in the https://github.com/waku-org/pm repo with `milestone` label assigned.
-- MUST have a GH Milestone in https://github.com/waku-org/pm repo, to which relevant _Epics of epics_ are added.
+- MUST have a GH Milestone in https://github.com/waku-org/pm repo, to which relevant _Epics_ are added.
 - SHOULD have a roadmap to delivery done at planning phase, the GH milestone is then used to track progress.
 
-An _Epic of epics_:
+An _Epic_:
 - MUST have a matching GH issue in the https://github.com/waku-org/pm with `epic` label assigned.
 - MUST have a label with format `E:<epic name>` created across all relevant https://github.com/waku-org/ repos (see [labels.yml](./.github/labels.yml)).
 - SHOULD be added to a GH Milestone.
-- SHOULD list _Epics_ present in other repos.
-
-An _Epic_:
-- MUST have a matching GH issue under the relevant https://github.com/waku-org/ repo, that
-  - MUST BE labelled with related _Epic of epics_ label (`E:...`)
-  - MUST BE labelled `epic` label.
-  - MUST be assigned to the _owner_ of the _Epic_.
-  - SHOULD contain a list of _Tasks_ in its issue description.
+- MAY list _Tasks_ present in other repos.
 
 A _Task_:
-- MAY be tracked as a todo item in an _Epic_ GH Issue,
-- OR MAY be tracked as GH issue
-  - that SHOULD be labelled with related _Epic of epics_ label (`E:...`),
+- MAY be tracked as a todo item in a GH Issue (_Task_ or _Epic_),
+- OR MAY be tracked as a single GH issue
+  - that MUST be labelled with related _Epic_ label (`E:...`),
 - OR MAY be tracked as a GH Pull Request
-  - that SHOULD be labelled with related _Epic of epics_ label (`E:...`).
-
+    - that MUST be labelled with related _Epic_ label (`E:...`),
+- MUST have an _acceptance criteria_ and/or a list of _tasks_ (that can be other GH issues).
 
 Which means, in terms of _navigation_:
 
 - Work for a Milestone is described in the related GitHub issue and tracked in the GitHub milestone.
-- In the GitHub milestone, we have a list of _Epics of epics_ to be achieved, the _Epics of epics_ are being closed as the work is done across all clients.
-- To look at remaining work for an _epics of epics_, one need to look at all issues (_epics_ and _tasks_) with the corresponding _epic of epics_ label (`E:...`)
-
-Finally, ideally an _Epic of epics_ do list the _epics_ as a todo list in the GH issue description, but it's not mandatory for tracking.
-The same way, an _Epic_ should list the _tasks_ as a todo list in the GH issue description, but it's not mandatory as long as the _acceptance criteria_ is clearly defined.
+- In the GitHub milestone, we have a list of _Epics_ to be achieved, the _Epics_ are being closed as the work is done across all clients.
+- To look at remaining work for an _Epic_, one need to look at all issues/PRs (_Tasks_) with the corresponding _Epic_ label (`E:...`)
 
 ### Reporting
 
@@ -79,9 +68,11 @@ The same way, an _Epic_ should list the _tasks_ as a todo list in the GH issue d
 
 Handled by insight team
 
-**Weekly**: Report progress on each **active** _Epic_ per subteam.
+**Weekly**: Report progress on each **active** _Epic_ or _Task_ per subteam.
 
-Every Friday, all team members must add a comment to the _Epic_ GH issue they own and worked on the past week or planned to work on next week.
+Every Friday, all team members must add a comment to the GH issues they own and worked on the past week or planned to work on next week.
+
+If work is done on several _Tasks_ related to the same _Epic_, team member is free to do their weekly update in common parent issue.
 
 The comment must have the following MarkDown format:
 


### PR DESCRIPTION
Trying to make things simpler and aligned with what the Insight dashboard can do:

In short, _Key Milestones_ are historical milestones for the project that we will broadcast, celebrate and demonstrate key achievement to Waku's progress.
I suggest to clear up the existing "milestones" and keep the following:
- Launch of Waku Network Gen 0
- Quality Assurance processes are in place
    - extend the scope to js-waku, and all non-regression testing forms such as functional and performance
    - Likely achieved in 2024
    - Strong signal for the quality of the software, collaboration with DST and for mature projects
- Support Many Platforms
	- We can extend the scope based on a survey we will do. And this must include docs for each SDK and examples. To be achieved in 2024

See at the end for the proposed tidy up of existing milestones.

Future milestones are likely to be:
- launching first incentivization protocol on mainnet
- Fully decentralized store services
Depending on the timing, this actually just be a "Waku Network Gen 1" milestone.

Each "X.X" item in https://github.com/waku-org/research/issues/3 become an _Epic_ with a corresponding issue in pm repo and a matching `E:...` label.
For example `1.2: Autosharding for autoscaling` gets:
- issue in pm repo "1.2: Autosharding for autoscaling"
- label in all repos `E:Autosharding`
- Issue is added to GH milestone (in pm repo) "Waku Network Gen 0"

Then, work for each client is tracked with one or several issues in the client's repo.

For example:
- go-waku: "autosharding issue", it has label  `E:Autosharding` assigned
- nwaku: autosharding,, it has label  `E:Autosharding` assigned  
- etc


----

Clean-up of current milestones:

- Support Many Platforms (key milestone for 2024)
	**- Make it a key milestone**
	- scope a number of languages (NodeJS, Python, C, Golang, Java?, Mobile platforms!)
	- Based on upcoming survey
	- Scope docs+example+library+docs
	- to be achieved in 2024
- First protocol to incentivize operators
	- replaced/becomes "Further milestones: Basic design for service incentivization" (epic of epics)
	- Will be part of a Key Milestone: incentivization protocol is mainnet/Waku Gen 1
- Dogfooding of RLN
	- close it, replaced with epics of "3. DoS Protection track"
- Execute an array of community growth activies
	- Close this one once all eco dev activities are tracked in notion
- Metrics
	- This becomes an Epic (not part of a key milestone)
- QA processes
	- **Keep it as a milestone.**
	- scope js-waku
	- scope non-regression performance test
	- Will be achieved in 2024
- peer management strategy
	- close this one
	- remaining work should be tracked under epics for Waku Network Gen 0
- Basic dev rel assets
	- Close this one once all eco dev activities are tracked in notion
- waku network supports 1 million users
	- close it, in favour of Waku network Gen 0 milestone (or it becomes it?)
	- 10k simulations are now part of the Waku Network Gen 0 milestone, as it is used to drive parameter selection for Waku network (e.g. number of members in RLN)
- Restricted-run protoocls are proudction ready
	- Close it once peer-exchange is done next week
- Waku network support 10k users
	- Close it once remaining work is done.
	
