### PR TITLE
Optimising for small and few milestones

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -115,7 +115,7 @@ A _Deliverable_:
 - MUST have an _Output_ section in the description detailing the result of work of the Deliverable, this may be a list of FURPS.
 - If tracking FURPS, the FURPS only belong to one feature aka FURPS set.
 - MUST have only one owner, assigned to the GitHub issue; a Waku subteam lead or team member.
-- MUST NOT have a dependency on another deliverable in the **same** milestone.
+- SHOULD NOT have a dependency on another deliverable in the **same** milestone.
 - MUST have a checklist to ensure the following items are done:
   - specs
   - code

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -115,6 +115,7 @@ A _Deliverable_:
 - MUST have an _Output_ section in the description detailing the result of work of the Deliverable, this may be a list of FURPS.
 - If tracking FURPS, the FURPS only belong to one feature aka FURPS set.
 - MUST have only one owner, assigned to the GitHub issue; a Waku subteam lead or team member.
+- MUST NOT have a dependency on another deliverable in the **same** milestone.
 - MUST have a checklist to ensure the following items are done:
   - specs
   - code


### PR DESCRIPTION
- few milestones: we should get most of the team working on the same milestones together.
- small milestone: avoid over-scoping milestones and aim to deliver early and iterate

Hence, all deliverables in a milestones should be worked on in parallel, with no dependencies beyond the initial spec writing and final interop testing/dogfooding.