### PR TITLE
Furps for mix

### DIFF
--- a/FURPS/core/mix.md
+++ b/FURPS/core/mix.md
@@ -2,10 +2,10 @@
 
 ## Functionality
 
-1. Relay nodes can mount mixnet protocol, acting as entry, exit or mixnet nodes
-2. Nodes can discover mixnet relay and exit nodes using existing peer discovery mechanisms
-3. Client nodes can send lightpush requests over the mixnet before delivery to a service node
-4. Client nodes can receive a response to a lightpush request over the mixnet
+1. Relay nodes can mount mixnet protocol, acting as entry, exit or mixnet nodes.
+2. Nodes can discover mixnet relay and exit nodes using available peer discovery mechanisms.
+3. Client nodes can send light push requests over the mixnet before delivery to a service node.
+4. Client nodes can receive a response to a light push request over the mixnet.
 
 ## Usability
 

--- a/FURPS/core/mix.md
+++ b/FURPS/core/mix.md
@@ -1,0 +1,18 @@
+# Mixnet FURPS
+
+## Functionality
+
+1. Relay nodes can mount mixnet protocol, acting as entry, exit or mixnet nodes
+2. Nodes can discover mixnet relay and exit nodes using existing peer discovery mechanisms
+3. Client nodes can send lightpush requests over the mixnet before delivery to a service node
+4. Client nodes can receive a response to a lightpush request over the mixnet
+
+## Usability
+
+## Reliability
+
+## Performance
+
+## Supportability
+
+## + (Privacy, Anonymity, Deployments)

--- a/draft-roadmap/README.md
+++ b/draft-roadmap/README.md
@@ -83,7 +83,7 @@ In order of priority.
 5. [Deploy RLN Onchain Tree on L2 Testnet](/draft-roadmap/deploy_rln_onchain_tree_on_l2_testnet.md)
 6. [Define Incentivisation for RLNaaS](/draft-roadmap/define_incentivisation_for_rlnaas.md)
 7. [Improve DevEx: API, TWN, Metrics, Docs](/draft-roadmap/improve_devex_api_twn_metrics_docs.md)
-8. [Introduce mixnet for message sending]() TODO: refining definition with @jm-clius. Suggesting mixnet relay deployed on TWN + light push over mixnet available in nwaku cli.
+8. [Introduce mixnet for message sending](/draft-roadmap/introduce_mixnet_for_message_sending.md)
 9. [Formalize Logos Web Apps](/draft-roadmap/formalize_logos_web_apps.md)
 10. [Introduce Chat SDK by enabling basic one-to-one chats]() TODO: should be added by https://github.com/waku-org/pm/pull/303
 11. [Integrate RLN with Waku API](/draft-roadmap/integrate_rln_with_waku_api.md)

--- a/draft-roadmap/introduce_mixnet_for_message_sending.md
+++ b/draft-roadmap/introduce_mixnet_for_message_sending.md
@@ -18,10 +18,11 @@ A PoC implementation to improve anonymity in Waku message publishing by mixing W
 **Feature**: [Mix](/FURPS/core/mix.md)
 
 **FURPS**:
-- F1. Relay nodes can mount mixnet protocol, acting as entry, exit or mixnet nodes
-- F2. Nodes can discover mixnet relay and exit nodes using existing peer discovery mechanisms
-- F3. Client nodes can send lightpush requests over the mixnet before delivery to a service node
-- F4. Client nodes can receive a response to a lightpush request over the mixnet
+- F1. Relay nodes can mount mixnet protocol, acting as entry, exit or mixnet nodes.
+- F2. Nodes can discover mixnet relay and exit nodes using available peer discovery mechanisms.
+- F3. Client nodes can send light push requests over the mixnet before delivery to a service node.
+- F4. Client nodes can receive a response to a light push request over the mixnet.
+
 
 **Checklist**:
 - [ ] Specs: link to specs

--- a/draft-roadmap/introduce_mixnet_for_message_sending.md
+++ b/draft-roadmap/introduce_mixnet_for_message_sending.md
@@ -1,0 +1,30 @@
+# Introduce Mixnet For Message Sending
+
+**Estimated date of completion**: {Enter date}
+
+**Resources Required for 2025H2**:
+- 1 core research engineer for 3 months
+
+A PoC implementation to improve anonymity in Waku message publishing by mixing Waku Lightpush requests and responses.
+
+**FURPS** (see deliverables)
+
+**GitHub Milestone and deliverables**:
+
+## [Integrate libp2p mix into lightpush](https://github.com/waku-org/nwaku/issues/3280)
+
+**Owner**: core research
+
+**Feature**: [Mix](/FURPS/core/mix.md)
+
+**FURPS**:
+- F1. Relay nodes can mount mixnet protocol, acting as entry, exit or mixnet nodes
+- F2. Nodes can discover mixnet relay and exit nodes using existing peer discovery mechanisms
+- F3. Client nodes can send lightpush requests over the mixnet before delivery to a service node
+- F4. Client nodes can receive a response to a lightpush request over the mixnet
+
+**Checklist**:
+- [ ] Specs: link to specs
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or docs.waku.org (TBD)


### PR DESCRIPTION
Not complete but contains a proposal for the Fs of the Mixnet milestone. Scope is limited, but does this cover what you had in mind? For me, "Relay nodes can mount mixnet protocol..." covers "TWN deployment of mixnet relay node". Anything implemented in nwaku and released is in theory "deployed" to TWN.