### PR TITLE
chore: suggest orphan PRs labeling procedure

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -122,7 +122,7 @@ A _Deliverable_:
   - dogfooding
   - docs
 
-Finally, for _Tasks_ that do not belong to a _Deliverable_:
+Finally, for _Tasks_ or _PRs_ that do not belong to a _Deliverable_:
 - MUST qualify either as (with related GitHub labels):
   - `bug`: bugs reported by users or discovered internally, SHOULD be linked back to a corresponding _FURPS_ and _Milestone_.
   - `test`: maintaining and fixing broken tests, SHOULD ideally be linked back to a corresponding _FURPS_ and _Milestone_.


### PR DESCRIPTION
PRs that don't directly belong to a certain roadmap _Deliverable_ should be properly labeled with either:
- bug
- dependencies
- release
- test 