### PR TITLE
Add nim-ffi suggestion

### DIFF
--- a/FURPS/application/nim_ffi.md
+++ b/FURPS/application/nim_ffi.md
@@ -1,0 +1,25 @@
+# {Feature Name} FURPS
+
+## Functionality
+
+1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to FFI.
+
+## Usability
+
+1.  Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
+
+## Reliability
+
+1. ...
+
+## Performance
+
+1. ...
+
+## Supportability
+
+1. Can be installed using Nimble.
+
+## + (Privacy, Anonymity, Deployments)
+
+1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.

--- a/FURPS/application/nim_ffi.md
+++ b/FURPS/application/nim_ffi.md
@@ -1,4 +1,4 @@
-# {Feature Name} FURPS
+# Nim-FFI FURPS
 
 ## Functionality
 
@@ -6,20 +6,18 @@
 
 ## Usability
 
-1.  Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
+1. Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
 2. Any Nim project can use it and can be installed using Nimble,
-similarly to how nim-chronos is imported.
-3. The interaction with the exposed C library is through JSON.
-4. The interaction with the exposed C library is through protobuf.
+   similarly to how nim-chronos is imported.
+3. The interaction with the exposed C library can be done using JSON.
+4. The interaction with the exposed C library can be done using protobuf.
 
 ## Reliability
 
-1. The exposed C library does not leak memory.
+1. Nim-FFI does not leak memory.
 2. The exposed C library never hangs when working asynchronously.
 
 ## Performance
-
-1. ...
 
 ## Supportability
 

--- a/FURPS/application/nim_ffi.md
+++ b/FURPS/application/nim_ffi.md
@@ -3,13 +3,14 @@
 ## Functionality
 
 1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to a C-FFI library.
-2. The exposed C library can be used in Golang.
-3. The exposed C library can be used in Rust.
-4. The exposed C library can be used in Python.
 
 ## Usability
 
 1.  Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
+2. Any Nim project can use it and can be installed using Nimble,
+similarly to how nim-chronos is imported.
+3. The interaction with the exposed C library is through JSON.
+4. The interaction with the exposed C library is through protobuf.
 
 ## Reliability
 
@@ -22,10 +23,9 @@
 
 ## Supportability
 
-1. Any Nim project can use it and can be installed using Nimble,
-similarly to how nim-chronos is imported.
-2. The interaction with the exposed C library is through JSON.
-3. The interaction with the exposed C library is through protobuf.
+1. The exposed C library can be used in Golang.
+2. The exposed C library can be used in Rust.
+3. The exposed C library can be used in Python.
 
 ## + (Privacy, Anonymity, Deployments)
 

--- a/FURPS/application/nim_ffi.md
+++ b/FURPS/application/nim_ffi.md
@@ -2,7 +2,10 @@
 
 ## Functionality
 
-1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to FFI.
+1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to a C-FFI library.
+2. The exposed C library can be used in Golang.
+3. The exposed C library can be used in Rust.
+4. The exposed C library can be used in Python.
 
 ## Usability
 
@@ -10,7 +13,8 @@
 
 ## Reliability
 
-1. ...
+1. The exposed C library does not leak memory.
+2. The exposed C library never hangs when working asynchronously.
 
 ## Performance
 
@@ -18,8 +22,12 @@
 
 ## Supportability
 
-1. Can be installed using Nimble.
+1. Any Nim project can use it and can be installed using Nimble,
+similarly to how nim-chronos is imported.
+2. The interaction with the exposed C library is through JSON.
+3. The interaction with the exposed C library is through protobuf.
 
 ## + (Privacy, Anonymity, Deployments)
 
 1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
+

--- a/draft-roadmap/nim_usage_improvements.md
+++ b/draft-roadmap/nim_usage_improvements.md
@@ -85,7 +85,7 @@ This deliverable takes care of the following [Nim FFI](/FURPS/application/nim_ff
 
 - F1.
 - U1.
-- S1.
+- U2.
 - +1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
 
 **Checklist**:

--- a/draft-roadmap/nim_usage_improvements.md
+++ b/draft-roadmap/nim_usage_improvements.md
@@ -76,16 +76,29 @@ Note: maybe taken over by Vac-Nim
 - [ ] Docs: links to README.md or docs.waku.org (TBD)
 
 
-### Create nim-ffi, a Nim project to easily exposes c-bindings from Nim
+### Create nim-ffi, a library to easily exposes c-bindings from Nim
 
 **Owner**: nwaku
 
-**FURPS**:
-This deliverable takes care of the following [Nim FFI](/FURPS/application/nim_ffi.md) FURPS:
+**Feature**: [Nim FFI](/FURPS/application/nim_ffi.md)
 
-- F1.
-- U1.
-- U2.
+**FURPS**:
+
+- F1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to a C-FFI library.
+
+- U1. Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
+- U2. Any Nim project can use it and can be installed using Nimble,
+   similarly to how nim-chronos is imported.
+- U3. The interaction with the exposed C library can be done using JSON.
+- U4. The interaction with the exposed C library can be done using protobuf.
+
+- R1. Nim-FFI does not leak memory.
+- R2. The exposed C library never hangs when working asynchronously.
+
+- S1. The exposed C library can be used in Golang.
+- S2. The exposed C library can be used in Rust.
+- S3. The exposed C library can be used in Python.
+
 - +1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
 
 **Checklist**:

--- a/draft-roadmap/nim_usage_improvements.md
+++ b/draft-roadmap/nim_usage_improvements.md
@@ -76,22 +76,17 @@ Note: maybe taken over by Vac-Nim
 - [ ] Docs: links to README.md or docs.waku.org (TBD)
 
 
-### Create nim-ffi, a library to easily expose c-bindings from Nim
+### Create nim-ffi, a Nim project to easily exposes c-bindings from Nim
 
 **Owner**: nwaku
 
-**Feature**:
-- [Nim FFI](/FURPS/application/nim_ffi.md)
-
 **FURPS**:
+This deliverable takes care of the following [Nim FFI](/FURPS/application/nim_ffi.md) FURPS:
 
-- F1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to FFI.
-
-- U1.  Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
-
-- S1. Can be installed using Nimble.
-
-_ +1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
+- F1.
+- U1.
+- S1.
+- +1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
 
 **Checklist**:
 - [ ] Specs: link to specs and/or API definition

--- a/draft-roadmap/nim_usage_improvements.md
+++ b/draft-roadmap/nim_usage_improvements.md
@@ -76,23 +76,25 @@ Note: maybe taken over by Vac-Nim
 - [ ] Docs: links to README.md or docs.waku.org (TBD)
 
 
-### Create new nim-ffi repository that will allow exposing any Nim library in an easy way
+### Create nim-ffi, a library to easily expose c-bindings from Nim
 
 **Owner**: nwaku
 
 **Feature**:
-- [Waku SDK](/FURPS/core/waku_sdk.md)
-- [RLN SDK](/FURPS/core/rln_sdk.md)
-- [Chat SDK](/FURPS/application/chat_sdk.md)
-- [SDS](/FURPS/application/sds.md)
+- [Nim FFI](/FURPS/application/nim_ffi.md)
 
-**No FURPS**:
+**FURPS**:
 
-**Output**:
- - [ ] The `nim-ffi` repository provides the core logic needed to expose any synchronous or asynchronous Nim library. This involves meta-programming and the introduction of new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
+- F1. Provides the core logic needed to expose any synchronous or asynchronous Nim library to FFI.
 
- - [ ] `nim-ffi` can be installed using Nimble.
+- U1.  Introduce new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
 
- - [ ] The `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
+- S1. Can be installed using Nimble.
 
- - [ ] All Nim libraries should expose their APIs (functions, types, etc.) through `nim-ffi`.
+_ +1. `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
+
+**Checklist**:
+- [ ] Specs: link to specs and/or API definition
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or docs.waku.org (TBD)

--- a/draft-roadmap/nim_usage_improvements.md
+++ b/draft-roadmap/nim_usage_improvements.md
@@ -3,7 +3,7 @@
 **Estimated date of completion**: 19 Dec
 
 **Resources Required for 2025H2**:
-- 1 nwaku eng for 2 months
+- 2 nwaku eng for 3 months
 - Support from Vac/Nim team
 
 Improve usage of Nim related tooling and design patterns by proceedings with PoCs to discover potential gains and caveats.
@@ -74,3 +74,25 @@ Note: maybe taken over by Vac-Nim
 - [ ] Code: link to GitHub issues/PRs/Epic
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or docs.waku.org (TBD)
+
+
+### Create new nim-ffi repository that will allow exposing any Nim library in an easy way
+
+**Owner**: nwaku
+
+**Feature**:
+- [Waku SDK](/FURPS/core/waku_sdk.md)
+- [RLN SDK](/FURPS/core/rln_sdk.md)
+- [Chat SDK](/FURPS/application/chat_sdk.md)
+- [SDS](/FURPS/application/sds.md)
+
+**No FURPS**:
+
+**Output**:
+ - [ ] The `nim-ffi` repository provides the core logic needed to expose any synchronous or asynchronous Nim library. This involves meta-programming and the introduction of new pragma definitions, such as `{.ffi.}`, to appropriately annotate types and procedures.
+
+ - [ ] `nim-ffi` can be installed using Nimble.
+
+ - [ ] The `nwaku` repository uses `nim-ffi` to expose the existing `libwaku` functionality.
+
+ - [ ] All Nim libraries should expose their APIs (functions, types, etc.) through `nim-ffi`.


### PR DESCRIPTION
This PR adds a new deliverable: `Create nim-ffi`

The main purpose of this deliverable is to have a single source of truth for ffi-nim-based work and we aim to create a general-purpose repository that will help other Nim developers to expose their projects to other environments