### PR TITLE
docs: add permit functionality to allow single transactions registers

### DIFF
--- a/FURPS/core/rln_smart_contract.md
+++ b/FURPS/core/rln_smart_contract.md
@@ -13,6 +13,7 @@
 2. User does not need to wait for merkle tree synchronization and building to start relaying
    or sending messages.
 3. Application does not need to do a Web3 RPC call for every tree change to generate or validate messages.
+4. Application can transfer tokens and register membership with a single transaction.
 
 ## Reliability
 

--- a/draft-roadmap/integrate_rln_with_waku_api.md
+++ b/draft-roadmap/integrate_rln_with_waku_api.md
@@ -132,7 +132,7 @@ See deliverables.
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or docs.waku.org (TBD)
 
-### Improve RLN UX by reducing Web3 RPC calls
+### [Improve RLN UX by reducing contract interactions](https://github.com/waku-org/pm/issues/344)
 
 **Owner**: core research
 
@@ -140,6 +140,7 @@ See deliverables.
 
 **FURPS**:
 - U3. Application does not need to do a Web3 RPC call for every tree change to generate or validate messages.
+- U4. Application can transfer tokens and register membership with a single transaction.
 
 **Checklist**:
 - [ ] Specs: link to specs and/or API definition


### PR DESCRIPTION
Extended FURPS to allow for implementing permit functionality (i.e. allowing single-transaction registers for RLN). I changed the name of the existing deliverable to be broad enough to include this as well.