### PR TITLE
Update milestone due dates

### DIFF
--- a/draft-roadmap/improve_devex_api_twn_metrics_docs.md
+++ b/draft-roadmap/improve_devex_api_twn_metrics_docs.md
@@ -1,6 +1,6 @@
 # Improve DevEx: API, TWN, Metrics, Docs
 
-**Estimated date of completion**: 31 Aug
+**Estimated date of completion**: 27 Oct
 
 **Resources Required for 2025H2**:
 - 2 js-waku engineers

--- a/draft-roadmap/integrate_rln_with_waku_api.md
+++ b/draft-roadmap/integrate_rln_with_waku_api.md
@@ -1,6 +1,6 @@
 # Integrate RLN With the Waku API
 
-**Estimated date of completion**: 30 Sep
+**Estimated date of completion**: 27 Oct
 
 **Resources Required for 2025H2**:
 - 2 nwaku engineer for 2 months 


### PR DESCRIPTION
Update due dates to 27-Oct for (with justifications):

- Milestone: Integrate RLN With the Waku API
     - Endianness incompatibilites between nwaku and zerokit
     - Recently bumped zerokit to v0.9.0
     - Perform a refactor in nwaku's RLN code base given that the Merkle tree management is pure onchain

- Milestone: Improve DevEx: API, TWN, Metrics, Docs
   - Trial quic won't be done in short-term because the nim-libp2p is performing enhancements in there.
   - Big difficulties to properly handle sds+**nix**+status
   - Invested efforts in evolving nim-ffi + nim-ffi-protobuf for long term benefit across the Logos stack
   - Good progress on Waku API definition and soon we can start implement it in nwaku (`createNode` done,  `send` WIP)
